### PR TITLE
Help command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,7 @@ function logOption(title, description) {
 }
 
 async function cli() {
-  const res = await checkIfRepoisGit() && await getStagedFiles();
+  const res = (await checkIfRepoisGit()) && (await getStagedFiles());
   if (res) {
     return await inquirer
       .prompt([
@@ -51,4 +51,13 @@ async function cli() {
   }
 }
 
+if (process.argv[2] === "--help" || process.argv[2] === "-h") {
+  console.log("Command\t\t\tDescription\t\tType");
+  console.log("-------\t\t\t-----------\t\t----");
+  console.log("--help, -h\t\tShow help\t\tBoolean");
+  console.log("--version, -v\t\tShow version number\tBoolean");
+  console.log("--types, -t\t\tShow commit types\tBoolean");
+  console.log("\n");
+  process.exit(0);
+}
 export default cli;


### PR DESCRIPTION
## This PR is for #17 
#### - I have added the Help command which we can use with mct. e.g. ```mct -h``` or ```mct --help```
![image](https://user-images.githubusercontent.com/86144678/234972493-b63f36fe-9595-42a2-a139-d74141af6974.png)
#### - I used a basic approach not any library like Yargs or Commander. Because it's working fine for now but if libraries are needed in the long run, I can add that - actually, I've tried implementing it in Yargs as well If you want to add that...
#### - Review required @khattakdev  Sir
_**P.S: If this is good to go then we have to work on the ```--type``` and ```--version``` commands as well, obviously in a separate issue**_
